### PR TITLE
🤖 Fix invalid UUIDs

### DIFF
--- a/config.json
+++ b/config.json
@@ -36,7 +36,7 @@
     "concept": [],
     "practice": [
       {
-        "uuid": "ea77f8c4-2f69-11eb-adc1-0242ac120002",
+        "uuid": "7d8bfd7b-6b30-4e51-991b-97ac46079ab4",
         "practices": [],
         "prerequisites": [],
         "slug": "hello-world",
@@ -47,7 +47,7 @@
         ]
       },
       {
-        "uuid": "6b789dc6-303b-11eb-adc1-0242ac120002",
+        "uuid": "6093146b-069f-448b-b2b1-177b80b7bed6",
         "practices": [],
         "prerequisites": [],
         "slug": "resistor-color-duo",


### PR DESCRIPTION
This PR regenerates each UUID on the track that was invalid.

To be valid, each value of a `uuid` key must:
- Be a well-formed version 4 UUID (compliant with RFC 4122) in the
  canonical textual representation [1]
- Not exist elsewhere on the track
- Not exist elsewhere on Exercism

A track can generate a suitable UUID by running `configlet uuid`.

In the future, `configlet lint` will produce an error for an invalid
UUID.

[1] That is, it must match this regular expression:
```
^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$
```

## Tracking

https://github.com/exercism/v3-launch/issues/29
