### PR TITLE
🤖 Simplify `hello-world` stub

### DIFF
--- a/exercises/practice/hello-world/contracts/hello-world.sol
+++ b/exercises/practice/hello-world/contracts/hello-world.sol
@@ -2,6 +2,6 @@ pragma solidity 0.6.12;
 
 contract HelloWorld {
     function sayHelloWorld() external pure returns (string memory) {
-        return "Hello Universe";
+        return "Goodbye, Mars!";
     }
 }


### PR DESCRIPTION
Simplify the `hello-world` exercise's stub. The goal of this is to make things easier for students to get started and to introduce as little syntax as possible.

See https://github.com/exercism/v3-launch/issues/46