### PR TITLE
Tags for Solidity in config

### DIFF
--- a/config.json
+++ b/config.json
@@ -74,11 +74,7 @@
   "concepts": [],
   "key_features": [],
   "tags": [
-    "paradigm/contract_oriented",
     "paradigm/object_oriented",
-    "paradigm/transactional",
-    "typing/strong",
-    "runtime/evm",
-    "platform/blockchain"
+    "typing/strong"
   ]
 }

--- a/config.json
+++ b/config.json
@@ -73,5 +73,12 @@
   },
   "concepts": [],
   "key_features": [],
-  "tags": []
+  "tags": [
+    "paradigm/contract_oriented",
+    "paradigm/object_oriented",
+    "paradigm/transactional",
+    "typing/strong",
+    "runtime/evm",
+    "platform/blockchain"
+  ]
 }


### PR DESCRIPTION
There are three items added to this file that will still prevent
a "pass" from `configlet lint`.

These entries, or at least suitable entries, will need to be added to
the exercism/configlet/src/lint/track_config.nim file (as of this work).

See exercism/configlet#454 for the discussion concerning the above file
in regards to this language.

closes: #9