### PR TITLE
CI: pin GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
       - name: Use Node LTS
-        uses: actions/setup-node@v2.4.1
+        uses: actions/setup-node@270253e841af726300e85d718a5f606959b2903c
         with:
           # Here, use the LTS/stable version of the track's tooling, e.g.:
           node-version: 12.4
@@ -50,9 +50,9 @@ jobs:
         # Optionally, add more matrix variables, such as os or arch
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
       - name: Use Node ${{ matrix.version }}
-        uses: actions/setup-node@v2.4.1
+        uses: actions/setup-node@270253e841af726300e85d718a5f606959b2903c
 
       - name: Install project dependencies
         run: yarn

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
 
       - name: Use Node.js LTS (12.x)
-        uses: actions/setup-node@v2.4.1
+        uses: actions/setup-node@270253e841af726300e85d718a5f606959b2903c
         with:
           # Here, use the LTS/stable version of the track's tooling, e.g.:
           # node-version: 12.x
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Use Node ${{ matrix.version }}
-        uses: actions/setup-node@v2.4.1
+        uses: actions/setup-node@270253e841af726300e85d718a5f606959b2903c
 
       - name: Install project dependencies
         run: yarn


### PR DESCRIPTION
This PR updates GitHub Actions workflows to a specific version.
This ensures that the workflow will always run the same code, which makes your build _stable_.
It will also prevent a potential security issue where a tag could be replaced by a malicious commit without consumers being aware of it.

The PR updates each non-SHA based workflow reference with the SHA of the referenced version/tag, so the current behavior should not change.

See https://exercism.org/docs/building/github/gha-best-practices#h-pin-actions-to-shas for more information.